### PR TITLE
Fix demo deck fallback when deck.md doesn't exist

### DIFF
--- a/QuarkusReveal.java
+++ b/QuarkusReveal.java
@@ -86,6 +86,8 @@ public class QuarkusReveal implements Callable<Integer> {
                 throw new IOException("Deck file not found: " + deck);
             }
         }
+        // Only read if not using the demo deck
+        if (!resolvedDeck.equals("DEMO")) {
         var content = FILE_CACHE.read(deckPath).contentAsString();
         if (hasFrontMatter(content)) {
             final var fm = parseFrontMatter(content);
@@ -102,6 +104,7 @@ public class QuarkusReveal implements Callable<Integer> {
             setFromFM(fm, "height");
             setFromFM(fm, "margin");
         }
+    }
         System.setProperty("deck", resolvedDeck);
         System.setProperty("title", title);
         System.setProperty("theme", "theme-" + theme);


### PR DESCRIPTION
- Prevents IOException when falling back to demo content

![image](https://github.com/user-attachments/assets/09b20b68-76a9-46d3-878f-ad40f6312bd5)

- Fixes : #4